### PR TITLE
change regex to match what happens in practice

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Below is a simple prairie application,
 app(
   route(
     'get',
-    '^$',
+    '^/$',
     function(req) {
       res <- response()
       
@@ -25,7 +25,7 @@ app(
   # method, path, and handler
   list(
     method = c('get', 'post'),
-    path = '^data$',
+    path = '^/data$',
     handler = function(req) {
       if (method(req) == 'get') {
         as.response(iris) # because who doesn't want iris data?


### PR DESCRIPTION
I had to change the example to work on my machine. It may have something to do with my version of `httpuv` 

```
> sessionInfo('httpuv')
R version 3.2.2 (2015-08-14)
Platform: x86_64-w64-mingw32/x64 (64-bit)
Running under: Windows 7 x64 (build 7601) Service Pack 1

locale:
[1] LC_COLLATE=English_United States.1252  LC_CTYPE=English_United States.1252    LC_MONETARY=English_United States.1252
[4] LC_NUMERIC=C                           LC_TIME=English_United States.1252    

attached base packages:
character(0)

other attached packages:
[1] httpuv_1.3.3

loaded via a namespace (and not attached):
 [1] Rcpp_0.12.8     grDevices_3.2.2 assertthat_0.1  digest_0.6.10   withr_1.0.2     bitops_1.0-6    mime_0.5       
 [8] R6_2.2.0        jsonlite_1.1    xtable_1.8-2    magrittr_1.5    git2r_0.16.0    datasets_3.2.2  httr_1.2.1     
[15] stringi_1.1.2   utils_3.2.2     curl_2.3        graphics_3.2.2  devtools_1.12.0 base_3.2.2      tools_3.2.2    
[22] stringr_1.1.0   RCurl_1.95-4.8  shiny_0.14.2    stats_3.2.2     prairie_0.0.1.3 memoise_1.0.0   htmltools_0.3.5
[29] methods_3.2.2  
```